### PR TITLE
Actions: reuse output

### DIFF
--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: buildroot-hdc
-        path: output/images/firmware_update.raucb
+        path: output/firmware_update.raucb
     
   
   


### PR DESCRIPTION
It turns out that github actions removes anything that is inside the gitignore to force a clean build. 

This is annoying. 