### PR TITLE
Update github workflows for building and uploading HDC Firmware.

### DIFF
--- a/.github/workflows/clean_hdc.yml
+++ b/.github/workflows/clean_hdc.yml
@@ -1,0 +1,25 @@
+# This workflow is triggered manually by the user to clean up the project.
+# Do this if you are experiencing issues with compile_hdc.yml and want to start fresh.
+# Note that a clean build can take up to 6 hours.
+
+name: clean_hdc
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.CLASSIC_TOKEN }}
+          submodules: recursive
+      - name: Configure
+        run: |
+          make -s -C buildroot/ BR2_EXTERNAL=../dashcam O=../../output raspberrypicm4io_64_dev_dashcam_defconfig
+      - name: Make clean
+        run: |
+          cd ../output
+          make clean
+      - run: echo "Cleaned up project successfully, run compile_hdc to build again."

--- a/.github/workflows/clean_hdc.yml
+++ b/.github/workflows/clean_hdc.yml
@@ -6,7 +6,6 @@ name: clean_hdc
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   build:

--- a/.github/workflows/clean_hdc.yml
+++ b/.github/workflows/clean_hdc.yml
@@ -6,6 +6,7 @@ name: clean_hdc
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -17,11 +17,9 @@ jobs:
       - name: configure
         run: |
           make -s -C buildroot/ BR2_EXTERNAL=../dashcam O=../../output raspberrypicm4io_64_dev_dashcam_defconfig
-      # Note: If developing, remove `make clean`
       - name: Compile
         run: |
           cd ../output
-          make clean
           make
       - name: Generate timestamp
         id: timestamp

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -33,18 +33,18 @@ jobs:
         run: |
           cd ../output
           make
-      - name: Copy target
-        run: |
-          mkdir artifacts
-          cp ../output/images/update.raucb ./artifacts/firmware_update.raucb
       - name: Generate timestamp
         id: timestamp
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Extract firmware version from ODC API
         id: firmware_version
         run: echo "::set-output name=version::$(bash extract_firmware_version.sh)"
+      - name: Copy target
+        run: |
+          mkdir artifacts
+          cp ../output/images/update.raucb ./artifacts/${{ steps.timestamp.outputs.date }}_${{ steps.firmware_version.outputs.version }}.raucb
       - name: Upload
         uses: actions/upload-artifact@master
         with:
-          name: ${{ steps.timestamp.outputs.date }}-${{ steps.firmware_version.outputs.version }}.raucb
-          path: artifacts/firmware_update.raucb
+          name: buildroot-hdc
+          path: artifacts/${{ steps.timestamp.outputs.date }}_${{ steps.firmware_version.outputs.version }}.raucb

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    timeout-minutes: 600
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -5,12 +5,6 @@ on:
   push:
     tags:
       - "*"
-  # This allows us to call this workflow from deploy_s3.yml
-  workflow_call:
-    secrets:
-      token:
-        required: true
-
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -3,8 +3,8 @@ name: compile_hdc
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "*"
+    branches:
+      - main
 jobs:
   build:
     runs-on: self-hosted

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -16,6 +16,7 @@ jobs:
       - name: configure
         run: |
           make -s -C buildroot/ BR2_EXTERNAL=../dashcam O=../../output raspberrypicm4io_64_dev_dashcam_defconfig
+      # Note: If developing, remove `make clean`
       - name: Compile
         run: |
           cd ../output

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -37,8 +37,11 @@ jobs:
         run: |
           mkdir artifacts
           cp ../output/images/update.raucb ./artifacts/firmware_update.raucb
+      - name: Generate timestamp
+        id: timestamp
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Upload
         uses: actions/upload-artifact@master
         with:
-          name: buildroot-hdc
+          name: ${{ steps.timestamp.outputs.date }}-buildroot-hdc
           path: artifacts/firmware_update.raucb

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -7,7 +7,7 @@ on:
       - "*"
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Generate timestamp
         id: timestamp
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Extract firmware version from ODC API
+        id: firmware_version
+        run: echo "::set-output name=version::$(bash extract_firmware_version.sh)"
       - name: Upload
         uses: actions/upload-artifact@master
         with:
-          name: ${{ steps.timestamp.outputs.date }}-buildroot-hdc
+          name: ${{ steps.timestamp.outputs.date }}-${{ steps.firmware_version.outputs.version }}.raucb
           path: artifacts/firmware_update.raucb

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -16,18 +16,6 @@ jobs:
         with:
           token: ${{ secrets.CLASSIC_TOKEN }}
           submodules: recursive
-      # - uses: bettermarks/action-artifact-download@0.3.0
-      #   with:
-      #        token: ${{ secrets.CLASSIC_TOKEN }}
-      #        repo: hivemapper/odc-api
-      #        artifact_name: odc-api
-      #        wait_seconds: 30
-      # - run: |
-      #      ls -al odc-api
-      #      unzip odc-api
-      #      cp dashcam-api.js  dashcam/package/camera-node/files/dashcam-api.js
-      #      ls -al dashcam/package/camera-node/files/dashcam-api.js
-      #      md5sum dashcam/package/camera-node/files/dashcam-api.js
       - name: configure
         run: |
           make -s -C buildroot/ BR2_EXTERNAL=../dashcam O=../../output raspberrypicm4io_64_dev_dashcam_defconfig

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -14,18 +14,18 @@ jobs:
         with:
           token: ${{ secrets.CLASSIC_TOKEN }}
           submodules: recursive
-      - uses: bettermarks/action-artifact-download@0.3.0
-        with:
-             token: ${{ secrets.CLASSIC_TOKEN }}
-             repo: hivemapper/odc-api
-             artifact_name: odc-api
-             wait_seconds: 30
-      - run: |
-           ls -al odc-api
-           unzip odc-api
-           cp dashcam-api.js  dashcam/package/camera-node/files/dashcam-api.js
-           ls -al dashcam/package/camera-node/files/dashcam-api.js
-           md5sum dashcam/package/camera-node/files/dashcam-api.js
+      # - uses: bettermarks/action-artifact-download@0.3.0
+      #   with:
+      #        token: ${{ secrets.CLASSIC_TOKEN }}
+      #        repo: hivemapper/odc-api
+      #        artifact_name: odc-api
+      #        wait_seconds: 30
+      # - run: |
+      #      ls -al odc-api
+      #      unzip odc-api
+      #      cp dashcam-api.js  dashcam/package/camera-node/files/dashcam-api.js
+      #      ls -al dashcam/package/camera-node/files/dashcam-api.js
+      #      md5sum dashcam/package/camera-node/files/dashcam-api.js
       - name: configure
         run: |
           make -s -C buildroot/ BR2_EXTERNAL=../dashcam O=../../output raspberrypicm4io_64_dev_dashcam_defconfig

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "*"
+  # This allows us to call this workflow from deploy_s3.yml
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -7,7 +7,7 @@ on:
       - "*"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
         with:
@@ -19,6 +19,7 @@ jobs:
       - name: Compile
         run: |
           cd ../output
+          make clean
           make
       - name: Generate timestamp
         id: timestamp

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -7,6 +7,9 @@ on:
       - "*"
   # This allows us to call this workflow from deploy_s3.yml
   workflow_call:
+    secrets:
+      token:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   build:
     uses: Hivemapper/hdc_firmware/.github/workflows/compile_hdc.yml@cicd-test
+    secrets: inherit
   deploy:
     name: Upload Firmware to S3
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }} 
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-          aws_bucket: ${{ secrets.AWS_BUCKET }}
+          aws_bucket: dashcam-firmware
           source_dir: 'tmp/'
           destination_dir: ${{ github.ref_name }}

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -2,10 +2,13 @@ name: Deploy
 
 on: 
   workflow_dispatch:
+  workflow_run:
+    workflows: ["compile_hdc"]
+    types:
+      - completed
+    branches:
+      - master
 jobs:
-  build:
-    uses: Hivemapper/hdc_firmware/.github/workflows/compile_hdc.yml@cicd-test
-    secrets: inherit
   deploy:
     name: Upload Firmware to S3
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -2,13 +2,15 @@ name: Deploy
 
 on: 
   workflow_dispatch:
-   push:
-    tags:
-      - '*'
+  workflow_run:
+    workflows: ["compile_hdc"]
+    types:
+      - completed
 jobs:
-  deploy:
+  on-success:
     name: Upload Firmware to S3
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       deployments: write
     steps:
@@ -31,4 +33,10 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: dashcam-firmware
           source_dir: 'tmp/'
-          destination_dir: ${{ github.ref_name }}
+          destination_dir: hdc
+  on-failure:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo "Could not upload because the build failed."

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -2,15 +2,12 @@ name: Deploy
 
 on: 
   workflow_dispatch:
-  workflow_run:
-    workflows: ["compile_hdc"]
-    types:
-      - completed
 jobs:
-  on-success:
+  build:
+    uses: Hivemapper/hdc_firmware/.github/workflows/compile_hdc.yml@main
+  deploy:
     name: Upload Firmware to S3
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       deployments: write
     steps:
@@ -34,9 +31,4 @@ jobs:
           aws_bucket: dashcam-firmware
           source_dir: 'tmp/'
           destination_dir: ${{ github.ref_name}}
-  on-failure:
-    name: Notify on failure
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    steps:
-      - run: echo "Could not upload because the build failed."
+  

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -23,7 +23,7 @@ jobs:
           unzip buildroot-hdc
           ls -al 
           mkdir tmp
-          mv firmware_update.raucb tmp/
+          mv *.raucb tmp/
           echo  ${{ secrets.AWS_KEY_ID }} 
       - uses: shallwefootball/s3-upload-action@master
         with:

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -33,7 +33,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: dashcam-firmware
           source_dir: 'tmp/'
-          destination_dir: hdc
+          destination_dir: ${{ github.ref_name}}
   on-failure:
     name: Notify on failure
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy:
     name: Upload Firmware to S3
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       deployments: write
     steps:

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -34,5 +34,5 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: dashcam-firmware
           source_dir: 'tmp/'
-          destination_dir: ${{ github.ref_name}}
+          destination_dir: 'cicd'
   

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    uses: Hivemapper/hdc_firmware/.github/workflows/compile_hdc.yml@main
+    uses: Hivemapper/hdc_firmware/.github/workflows/compile_hdc.yml@cicd-test
   deploy:
     name: Upload Firmware to S3
     runs-on: ubuntu-latest

--- a/.github/workflows/super_clean_hdc.yml
+++ b/.github/workflows/super_clean_hdc.yml
@@ -6,6 +6,7 @@ name: super_clean_hdc
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/super_clean_hdc.yml
+++ b/.github/workflows/super_clean_hdc.yml
@@ -6,14 +6,11 @@ name: super_clean_hdc
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   build:
     runs-on: self-hosted
     steps:
-      - run: pwd
-      - run: ls -lH
       - name: Removing all old files
-        run: rm -rf ./*
+        run: rm -rf ./* ../output/*
       - run: echo "Cleaned up project successfully, run compile_hdc to build again."

--- a/.github/workflows/super_clean_hdc.yml
+++ b/.github/workflows/super_clean_hdc.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - run: pwd
       - run: ls -lH
-      # - name: Removing all old files
-      #   run: rm -rf ./*
+      - name: Removing all old files
+        run: rm -rf ./*
       - run: echo "Cleaned up project successfully, run compile_hdc to build again."

--- a/.github/workflows/super_clean_hdc.yml
+++ b/.github/workflows/super_clean_hdc.yml
@@ -6,11 +6,14 @@ name: super_clean_hdc
 
 on:
   workflow_dispatch:
+  push:
 
 jobs:
   build:
     runs-on: self-hosted
     steps:
-      - name: Removing all old files
-        run: rm -rf ./*
+      - run: pwd
+      - run: ls -lH
+      # - name: Removing all old files
+      #   run: rm -rf ./*
       - run: echo "Cleaned up project successfully, run compile_hdc to build again."

--- a/.github/workflows/super_clean_hdc.yml
+++ b/.github/workflows/super_clean_hdc.yml
@@ -6,7 +6,6 @@ name: super_clean_hdc
 
 on:
   workflow_dispatch:
-  push:
 
 jobs:
   build:

--- a/.github/workflows/super_clean_hdc.yml
+++ b/.github/workflows/super_clean_hdc.yml
@@ -1,0 +1,16 @@
+# This workflow is triggered manually by the user to completely erase the project.
+# Do this if you are experiencing issues with compile_hdc.yml and want to start fresh.
+# Note that a clean build can take up to 6 hours.
+
+name: super_clean_hdc
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Removing all old files
+        run: rm -rf ./*
+      - run: echo "Cleaned up project successfully, run compile_hdc to build again."

--- a/dashcam/package/hdc-acl/hdc-acl.mk
+++ b/dashcam/package/hdc-acl/hdc-acl.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HDC_ACL_VERSION = 1.1.4
-HDC_ACL_SITE = https://github.com/Hivemapper/hivemapper_hdc_acl/releases/download/v$(HDC_ACL_VERSION)
+HDC_ACL_SITE = https://github.com/streamingfast/hivemapper_hdc_acl/releases/download/v$(HDC_ACL_VERSION)
 HDC_ACL_SOURCE = hivemapper_hdc_acl_$(HDC_ACL_VERSION)_Linux_arm64.tar.gz
 HDC_ACL_STRIP_COMPONENTS = 0
 

--- a/dashcam/package/hdc-acl/hdc-acl.mk
+++ b/dashcam/package/hdc-acl/hdc-acl.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 HDC_ACL_VERSION = 1.1.4
-HDC_ACL_SITE = https://github.com/streamingfast/hivemapper_hdc_acl/releases/download/v$(HDC_ACL_VERSION)
+HDC_ACL_SITE = https://github.com/Hivemapper/hivemapper_hdc_acl/releases/download/v$(HDC_ACL_VERSION)
 HDC_ACL_SOURCE = hivemapper_hdc_acl_$(HDC_ACL_VERSION)_Linux_arm64.tar.gz
 HDC_ACL_STRIP_COMPONENTS = 0
 

--- a/extract_firmware_version.sh
+++ b/extract_firmware_version.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-set -x
 camera_node_dir=$(find ../output/build -maxdepth 1 -type d -name 'camera-node-*')
-# echo $camera_node_dir
 dashcam_api_path=$camera_node_dir/compiled/odc-api-hdc.js
-# echo $dashcam_api_path
 # Extract the firmware version from the odc-api script and transform it to X_Y_Z format
 grep -m 1 "exports.API_VERSION = '" $dashcam_api_path | sed -n "s/.*'\(.*\)'.*/\1/p" | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1-\2-\3/g'

--- a/extract_firmware_version.sh
+++ b/extract_firmware_version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-camera_node_dir=$(find output/build -maxdepth 1 -type d -name 'camera-node-*')
+camera_node_dir=$(find ../output/build -maxdepth 1 -type d -name 'camera-node-*')
 echo $camera_node_dir
 dashcam_api_path=$camera_node_dir/compiled/odc-api-hdc.js
 
 # Extract the firmware version from the odc-api script and transform it to X_Y_Z format
-grep -m 1 "exports.API_VERSION = '" $dashcam_api_path | sed -n "s/.*'\(.*\)'.*/\1/p" | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1_\2_\3/g'
+grep -m 1 "exports.API_VERSION = '" $dashcam_api_path | sed -n "s/.*'\(.*\)'.*/\1/p" | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1-\2-\3/g'

--- a/extract_firmware_version.sh
+++ b/extract_firmware_version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+camera_node_dir=$(find output/build -maxdepth 1 -type d -name 'camera-node-*')
+echo $camera_node_dir
+dashcam_api_path=$camera_node_dir/compiled/odc-api-hdc.js
+
+# Extract the firmware version from the odc-api script and transform it to X_Y_Z format
+grep -m 1 "exports.API_VERSION = '" $dashcam_api_path | sed -n "s/.*'\(.*\)'.*/\1/p" | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1_\2_\3/g'

--- a/extract_firmware_version.sh
+++ b/extract_firmware_version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -x
 camera_node_dir=$(find ../output/build -maxdepth 1 -type d -name 'camera-node-*')
-echo $camera_node_dir
+# echo $camera_node_dir
 dashcam_api_path=$camera_node_dir/compiled/odc-api-hdc.js
-echo $dashcam_api_path
+# echo $dashcam_api_path
 # Extract the firmware version from the odc-api script and transform it to X_Y_Z format
 grep -m 1 "exports.API_VERSION = '" $dashcam_api_path | sed -n "s/.*'\(.*\)'.*/\1/p" | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1-\2-\3/g'

--- a/extract_firmware_version.sh
+++ b/extract_firmware_version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-
+set -x
 camera_node_dir=$(find ../output/build -maxdepth 1 -type d -name 'camera-node-*')
 echo $camera_node_dir
 dashcam_api_path=$camera_node_dir/compiled/odc-api-hdc.js
-
+echo $dashcam_api_path
 # Extract the firmware version from the odc-api script and transform it to X_Y_Z format
 grep -m 1 "exports.API_VERSION = '" $dashcam_api_path | sed -n "s/.*'\(.*\)'.*/\1/p" | sed 's/\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\)/\1-\2-\3/g'


### PR DESCRIPTION
Ticket: https://github.com/Hivemapper/hdc_firmware/issues/212

`compile_hdc` workflow compiles the project.
`deploy_s3` workflow uploads to the `cicd` folder in the `dashcam-firmware` bucket. This was intentional to prevent accidentally overwriting an existing release.  The user must manually move the new firmware from `cicd` to the root directory.

Also added "clean" and "super clean" workflows to allow clean installs

Some limitations: Self hosted runner supports only one build at a time as far as I know