### PR TITLE
HDC Build workflow improvements

### DIFF
--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Compile
         run: |
           cd ../output
-          make camera-node-dirclean camera-bridge-dirclean data-logger-dirclean usb-writer-dirclean
+          make camera-node-dirclean camera-bridge-dirclean data-logger-dirclean usb-write-dirclean
           make
       - name: Generate timestamp
         id: timestamp

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -1,3 +1,6 @@
+# HDC Build Server needs to be enabled for this workflow to run
+# https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#InstanceDetails:instanceId=i-0e2df2f7d6610d647
+
 name: compile_hdc
 
 on:

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -36,9 +36,10 @@ jobs:
       - name: Copy target
         run: |
           mkdir artifacts
+          cp ../output/target/etc/version.json ./artifacts/version.json
           cp ../output/images/update.raucb ./artifacts/${{ steps.timestamp.outputs.date }}_${{ steps.firmware_version.outputs.version }}.raucb
       - name: Upload
         uses: actions/upload-artifact@master
         with:
           name: buildroot-hdc
-          path: artifacts/${{ steps.timestamp.outputs.date }}_${{ steps.firmware_version.outputs.version }}.raucb
+          path: artifacts

--- a/.github/workflows/compile_hdc.yml
+++ b/.github/workflows/compile_hdc.yml
@@ -17,10 +17,12 @@ jobs:
       - name: configure
         run: |
           make -s -C buildroot/ BR2_EXTERNAL=../dashcam O=../../output raspberrypicm4io_64_dev_dashcam_defconfig
+      # Buildroot is not good at picking up when a package needs to be rebuilt.
+      # Force clean the most commonly modified packages.
       - name: Compile
         run: |
           cd ../output
-          make camera-node-dirclean
+          make camera-node-dirclean camera-bridge-dirclean data-logger-dirclean usb-writer-dirclean
           make
       - name: Generate timestamp
         id: timestamp

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Grab version.json
         id: firmware_version_json
-        run: echo "::set-output name=version::$(cat version.json)"
+        run: echo "::set-output name=version::$(cat version.json | tr -d '\n')"
 
       - uses: shallwefootball/s3-upload-action@master
         id: upload_s3

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -21,14 +21,21 @@ jobs:
           token: ${{ secrets.CLASSIC_TOKEN }}
           artifact_name: buildroot-hdc
           wait_seconds: 30
+
       - run: |
           ls -al
           rm -f *.raucb
+          rm -f version.json
           rm -rf tmp/
           unzip -o buildroot-hdc
           ls -al 
           mkdir tmp
           mv -f *.raucb tmp/
+
+      - name: Grab version.json
+        id: firmware_version_json
+        run: echo "::set-output name=version::$(cat version.json)"
+
       - uses: shallwefootball/s3-upload-action@master
         id: upload_s3
         with:
@@ -37,6 +44,7 @@ jobs:
           aws_bucket: dashcam-firmware
           source_dir: 'tmp/'
           destination_dir: 'cicd'
+
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
@@ -46,7 +54,7 @@ jobs:
           # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
           channel-id: 'hdc-firmware-deploy'
           # For posting a simple plain text message
-          slack-message: "*${{ github.actor }}* deployed an image based on ${{ github.ref }}\nSHA: ${{ github.sha }}\nURL: ${{ steps.upload_s3.outputs.object_locations }}"
+          slack-message: "*${{ github.actor }}* deployed an image based on ${{ github.ref }}\nSHA: ${{ github.sha }}\nVersion JSON:\n```${{ steps.firmware_version_json.version }}```\nURL: ${{ steps.upload_s3.outputs.object_locations }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Grab version.json
         id: firmware_version_json
         run: |
-          version_json=$(cat version.json | awk '{printf "%s\\n", $0}')
+          version_json=$(cat version.json | tr -d '\n')
           echo "::set-output name=version::$version_json)"
 
       - uses: shallwefootball/s3-upload-action@master

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Grab version.json
         id: firmware_version_json
-        run: echo "::set-output name=version::$(cat version.json | tr -d '\n')"
+        run: echo "::set-output name=version::$(cat version.json | awk '{printf \"%s\\n\", $0}')"
 
       - uses: shallwefootball/s3-upload-action@master
         id: upload_s3

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Grab version.json
         id: firmware_version_json
-        run: echo "::set-output name=version::$(cat version.json | awk '{printf \"%s\\n\", $0}')"
+        run: |
+          version_json=$(cat version.json | awk '{printf "%s\n", $0}')
+          echo "::set-output name=version::$version_json)"
 
       - uses: shallwefootball/s3-upload-action@master
         id: upload_s3

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Grab version.json
         id: firmware_version_json
         run: |
-          version_json=$(cat version.json | awk '{printf "%s\n", $0}')
+          version_json=$(cat version.json | awk '{printf "%s\\n", $0}')
           echo "::set-output name=version::$version_json)"
 
       - uses: shallwefootball/s3-upload-action@master

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -36,7 +36,7 @@ jobs:
         id: firmware_version_json
         run: |
           version_json=$(cat version.json | tr -d '\n')
-          echo "::set-output name=version::$version_json)"
+          echo "::set-output name=version::$version_json"
 
       - uses: shallwefootball/s3-upload-action@master
         id: upload_s3

--- a/.github/workflows/deploy_s3.yml
+++ b/.github/workflows/deploy_s3.yml
@@ -54,7 +54,7 @@ jobs:
           # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
           channel-id: 'hdc-firmware-deploy'
           # For posting a simple plain text message
-          slack-message: "*${{ github.actor }}* deployed an image based on ${{ github.ref }}\nSHA: ${{ github.sha }}\nVersion JSON:\n```${{ steps.firmware_version_json.version }}```\nURL: ${{ steps.upload_s3.outputs.object_locations }}"
+          slack-message: "*${{ github.actor }}* deployed an image based on ${{ github.ref }}\nSHA: ${{ github.sha }}\nVersion JSON:\n```${{ steps.firmware_version_json.outputs.version }}```\nURL: ${{ steps.upload_s3.outputs.object_locations }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           


### PR DESCRIPTION
Ticket: https://linear.app/hivemapper/issue/IMCO-196/cicd-improvements-and-bugfixes

- Add clean commands for specific packages
   - Buildroot is not good at picking up when a package needs to be rebuilt, so we force clean the most commonly modified packages.
- Add version.json to deploy message
   - SHA is not very reliable, it only reports the current head of the branch.  version.json is extracted from the firmware itself and is always accurate.

